### PR TITLE
feat: cert manager controller and action to download rootCA, runtime …

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -63,7 +63,7 @@ config :phoenix, :json_library, Jason
 config :tunneld, :auth,
   ttl: 1800 # 30 minutes
 
-config :tunneld, version: "0.9.2"
+config :tunneld, version: "0.10.0"
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,7 +16,13 @@ config :tunneld, :fs,
   root: System.get_env("TUNNELD_DATA", default_root),
   auth: System.get_env("TUNNELD_AUTH_FILE", "auth.json"),
   resources: System.get_env("TUNNELD_SHARES_FILE", "resources.json"),
-  sqm: System.get_env("TUNNELD_SQM_FILE", "sqm.json")
+  sqm: System.get_env("TUNNELD_SQM_FILE", "sqm.json"),
+  dns_file: System.get_env("TUNNELD_DNS_FILE", "/etc/dnsmasq.d/tunneld_resources.conf")
+
+config :tunneld, :certs,
+  cert_dir: System.get_env("TUNNELD_CERT_DIR", "/etc/nginx/certs"),
+  ca_dir: System.get_env("TUNNELD_CA_DIR", "/etc/tunneld/ca"),
+  ca_file: "rootCA.key"
 
 # Only require these in PROD
 if config_env() == :prod do
@@ -48,7 +54,7 @@ if config_env() == :prod do
 
   gateway_origin = System.get_env("GATEWAY", "")
   hostname = System.get_env("HOSTNAME", "")
-  check_origins = ["http://#{gateway_origin}", "http://localhost", "http://#{hostname}"]
+  check_origins = ["http://#{gateway_origin}", "http://localhost", "http://#{hostname}", "http://tunneld.local", "https://tunneld.local"]
 
   config :tunneld, TunneldWeb.Endpoint,
     url: [host: host, port: 80, scheme: "http"],

--- a/lib/tunneld/cert_manager.ex
+++ b/lib/tunneld/cert_manager.ex
@@ -1,0 +1,119 @@
+defmodule Tunneld.CertManager do
+  use GenServer
+  require Logger
+
+  # Check every 6 hours
+  @check_interval :timer.hours(6)
+  @validity_days "30"
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    # Run the check immediately on startup (async)
+    send(self(), :check_certs)
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:check_certs, state) do
+    check_and_renew_certs()
+    Process.send_after(self(), :check_certs, @check_interval)
+    {:noreply, state}
+  end
+
+  def generate_cert(reserve_name) do
+    config = Application.get_env(:tunneld, :certs, [])
+    cert_dir = Keyword.get(config, :cert_dir)
+    ca_dir = Keyword.get(config, :ca_dir)
+
+    key_path = Path.join(cert_dir, "#{reserve_name}.key")
+    csr_path = Path.join(cert_dir, "#{reserve_name}.csr")
+    crt_path = Path.join(cert_dir, "#{reserve_name}.crt")
+
+    # Ensure cert directory exists
+    File.mkdir_p!(cert_dir)
+
+    case get_root_domain() do
+      {:ok, root_domain} ->
+        Logger.info("Generating certificate for #{reserve_name}.#{root_domain}")
+
+        with {_, 0} <- System.cmd("openssl", ["genrsa", "-out", key_path, "2048"], stderr_to_stdout: true),
+             {_, 0} <- System.cmd("openssl", [
+               "req", "-new", "-key", key_path,
+               "-out", csr_path,
+               "-subj", "/CN=#{reserve_name}.#{root_domain}",
+               "-addext", "subjectAltName = DNS:#{reserve_name}.#{root_domain}"
+             ], stderr_to_stdout: true),
+             {_, 0} <- System.cmd("openssl", [
+               "x509", "-req", "-in", csr_path,
+               "-CA", Path.join(ca_dir, "rootCA.pem"),
+               "-CAkey", Path.join(ca_dir, "rootCA.key"),
+               "-CAcreateserial",
+               "-out", crt_path,
+               "-days", @validity_days,
+               "-sha256",
+               "-copy_extensions", "copy"
+             ], stderr_to_stdout: true) do
+          File.rm(csr_path)
+          Logger.info("Certificate generated successfully: #{crt_path}")
+          :ok
+        else
+          {out, _} ->
+            Logger.error("Failed to generate certificate for #{reserve_name}: #{out}")
+            {:error, out}
+        end
+
+      {:error, reason} ->
+        Logger.error("Skipping certificate generation for #{reserve_name}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  def delete_cert(reserve_name) do
+    config = Application.get_env(:tunneld, :certs)
+    cert_dir = Keyword.get(config, :cert_dir)
+
+    File.rm(Path.join(cert_dir, "#{reserve_name}.key"))
+    File.rm(Path.join(cert_dir, "#{reserve_name}.csr"))
+    File.rm(Path.join(cert_dir, "#{reserve_name}.crt"))
+    :ok
+  end
+
+  defp check_and_renew_certs do
+    config = Application.get_env(:tunneld, :certs, [])
+    cert_dir = Keyword.get(config, :cert_dir)
+
+    if File.exists?(cert_dir) do
+      cert_dir
+      |> File.ls!()
+      |> Enum.filter(&String.ends_with?(&1, ".crt"))
+      |> Enum.each(fn file ->
+        crt_path = Path.join(cert_dir, file)
+        if cert_expired?(crt_path) do
+          reserve_name = Path.basename(file, ".crt")
+          Logger.info("Certificate for #{reserve_name} is expired or expiring soon. Renewing...")
+          generate_cert(reserve_name)
+        end
+      end)
+    else
+      Logger.warning("Certificate directory #{cert_dir} does not exist. Skipping check.")
+    end
+  end
+
+  defp cert_expired?(crt_path) do
+    # Check if certificate expires within 24 hours (86400 seconds)
+    # Exit code 0 means it will NOT expire (Valid)
+    # Exit code 1 means it WILL expire (Invalid/Expired)
+    case System.cmd("openssl", ["x509", "-checkend", "86400", "-in", crt_path], stderr_to_stdout: true) do
+      {_, 0} -> false
+      _ -> true
+    end
+  end
+
+  defp get_root_domain do
+    Tunneld.Servers.Zrok.get_root_domain()
+  end
+end

--- a/lib/tunneld/servers/dnsmasq.ex
+++ b/lib/tunneld/servers/dnsmasq.ex
@@ -1,0 +1,65 @@
+defmodule Tunneld.Servers.Dnsmasq do
+  @moduledoc false
+  require Logger
+
+  def add_entry(subdomain) do
+    with {:ok, domain} <- get_domain() do
+      line = config_line(subdomain, domain)
+      file = config_file()
+
+      ensure_dir(file)
+
+      try do
+        current = if File.exists?(file), do: File.read!(file), else: ""
+
+        unless String.contains?(current, line) do
+          File.write!(file, line, [:append])
+          Logger.info("Added local DNS entry for #{subdomain}.#{domain}")
+        end
+      rescue
+        e -> Logger.error("Failed to add DNS entry: #{inspect(e)}")
+      end
+    end
+  end
+
+  def remove_entry(subdomain) do
+    with {:ok, domain} <- get_domain() do
+      line = config_line(subdomain, domain)
+      file = config_file()
+
+      if File.exists?(file) do
+        try do
+          current = File.read!(file)
+
+          if String.contains?(current, line) do
+            new_content = String.replace(current, line, "")
+            File.write!(file, new_content)
+            Logger.info("Removed local DNS entry for #{subdomain}.#{domain}")
+          end
+        rescue
+          e -> Logger.error("Failed to remove DNS entry: #{inspect(e)}")
+        end
+      end
+    end
+  end
+
+  defp get_domain do
+    Tunneld.Servers.Zrok.get_root_domain()
+  end
+
+  defp config_line(subdomain, domain) do
+    ip = get_target_ip()
+    "address=/#{subdomain}.#{domain}/#{ip}\n"
+  end
+
+  defp get_target_ip do
+    Application.get_env(:tunneld, :network, [])
+    |> Keyword.get(:gateway)
+  end
+
+  defp config_file do
+    Application.get_env(:tunneld, :fs)[:dns_file]
+  end
+
+  defp ensure_dir(path), do: Path.dirname(path) |> File.mkdir_p()
+end

--- a/lib/tunneld/servers/nginx.ex
+++ b/lib/tunneld/servers/nginx.ex
@@ -14,6 +14,10 @@ defmodule Tunneld.Servers.Nginx do
     available_path = available_path(id, mock?)
     enabled_path = enabled_path(id, mock?)
 
+    reserved = get_in(resource, ["tunneld", "reserved"]) || %{}
+    public_name = Map.get(reserved, "public", "#{id}-public")
+    Tunneld.CertManager.generate_cert(public_name)
+
     with :ok <- ensure_dirs(mock?),
          :ok <- ensure_pool(pool),
          :ok <- File.write(available_path, render_config(resource)),
@@ -68,8 +72,11 @@ defmodule Tunneld.Servers.Nginx do
     upstream_name = "tunneld_#{id}_pool"
     pool = Map.get(resource, "pool", [])
 
-    # Retrieve root domain from config if available (e.g. "example.com")
-    root_domain = Application.get_env(:tunneld, :root_domain)
+    root_domain =
+      case Tunneld.Servers.Zrok.get_root_domain() do
+        {:ok, domain} -> domain
+        _ -> nil
+      end
 
     # Logic to determine the Host header for private access:
     spoofed_host =
@@ -77,8 +84,8 @@ defmodule Tunneld.Servers.Nginx do
         String.contains?(public_name, ".") ->
           public_name
 
-        is_binary(root_domain) and root_domain != "" ->
-          public_name <> "." <> String.trim_leading(root_domain, ".")
+        root_domain ->
+          public_name <> "." <> root_domain
 
         true ->
           public_name
@@ -90,10 +97,44 @@ defmodule Tunneld.Servers.Nginx do
       |> Enum.reject(&(&1 == ""))
       |> Enum.map_join("\n", fn entry -> "    server #{entry};" end)
 
+    gateway_ip = Application.get_env(:tunneld, :network, []) |> Keyword.get(:gateway)
+    cert_dir = Application.get_env(:tunneld, :certs, []) |> Keyword.get(:cert_dir)
+    ssl_crt = Path.join(cert_dir, "#{public_name}.crt")
+    ssl_key = Path.join(cert_dir, "#{public_name}.key")
+
+    ssl_block = if root_domain do
+      """
+      server {
+          listen #{gateway_ip}:443 ssl;
+          server_name #{public_name}.#{root_domain};
+
+          ssl_certificate #{ssl_crt};
+          ssl_certificate_key #{ssl_key};
+
+          location / {
+              proxy_pass http://#{upstream_name};
+
+              client_max_body_size 0;
+              proxy_request_buffering off;
+
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto https;
+              proxy_set_header X-Forwarded-Port 443;
+          }
+      }
+      """
+    else
+      ""
+    end
+
     """
     upstream #{upstream_name} {
     #{servers}
     }
+
+    #{ssl_block}
 
     server {
         listen #{listen_ip}:#{public_port};

--- a/lib/tunneld/servers/resources.ex
+++ b/lib/tunneld/servers/resources.ex
@@ -4,7 +4,7 @@ defmodule Tunneld.Servers.Resources do
   """
   use GenServer
   require Logger
-  alias Tunneld.Servers.{Nginx, Zrok}
+  alias Tunneld.Servers.{Nginx, Zrok, Dnsmasq}
 
   @interval 10_000
   @nginx_ip "127.0.0.1"
@@ -69,6 +69,10 @@ defmodule Tunneld.Servers.Resources do
             type: :info,
             message: "resource added successfully"
           })
+
+          if pub = reserve_meta["reserved"]["public"] do
+            Dnsmasq.add_entry(pub)
+          end
 
           broadcast_shares()
           Map.put(state, :resources, u_nodes)
@@ -194,6 +198,7 @@ defmodule Tunneld.Servers.Resources do
 
             Zrok.reserve_public(pub_token, ip, port, basic_auth)
             Zrok.reserve_private(priv_token, ip, port)
+            Dnsmasq.add_entry(pub_token)
 
             # Ensure nginx config is present on boot/resync
             _ = ensure_nginx_config(s)
@@ -680,6 +685,8 @@ defmodule Tunneld.Servers.Resources do
             %{"public" => pub, "private" => priv} ->
               _ = Zrok.release_reserved(pub)
               _ = Zrok.release_reserved(priv)
+              Dnsmasq.remove_entry(pub)
+              Tunneld.CertManager.delete_cert(pub)
 
             _ ->
               :ok

--- a/lib/tunneld/servers/zrok.ex
+++ b/lib/tunneld/servers/zrok.ex
@@ -723,6 +723,22 @@ defmodule Tunneld.Servers.Zrok do
     do: GenServer.call(__MODULE__, {:set_api_endpoint, endpoint}, 30_000)
 
   def get_api_endpoint(), do: GenServer.call(__MODULE__, :get_api_endpoint, 15_000)
+
+  def get_root_domain do
+    case get_api_endpoint() do
+      url when is_binary(url) and url not in ["<unset>", "", nil] ->
+        case URI.parse(url).host do
+          nil -> {:error, :no_host}
+          host ->
+            domain = if String.starts_with?(host, "zrok."),
+              do: String.replace_prefix(host, "zrok.", ""),
+              else: host
+            {:ok, domain}
+        end
+      _ -> {:error, :unset}
+    end
+  end
+
   def unset_api_endpoint(), do: GenServer.call(__MODULE__, :unset_api_endpoint, 30_000)
 
   def enable_env(account_token),

--- a/lib/tunneld_web/live/components/sidebar/ca_controller.ex
+++ b/lib/tunneld_web/live/components/sidebar/ca_controller.ex
@@ -1,0 +1,16 @@
+defmodule TunneldWeb.CAController do
+  use TunneldWeb, :controller
+
+  def download(conn, _params) do
+    certs_config = Application.get_env(:tunneld, :certs)
+    ca_path = Path.join(certs_config[:ca_dir], certs_config[:ca_file])
+
+    conn
+    |> put_resp_content_type("application/x-x509-ca-cert")
+    |> put_resp_header(
+      "content-disposition",
+      "attachment; filename=\"#{certs_config[:ca_file]}\""
+    )
+    |> send_file(200, ca_path)
+  end
+end

--- a/lib/tunneld_web/live/components/sidebar/details.ex
+++ b/lib/tunneld_web/live/components/sidebar/details.ex
@@ -103,6 +103,20 @@ defmodule TunneldWeb.Live.Components.Sidebar.Details do
           <div class="truncate text-xs">WebAuthn</div>
         </div>
       </div>
+
+      <div class="mt-6 border-t border-gray-700 pt-4">
+        <p class="text-xs text-gray-400 mb-3">
+          Download and install the Root CA on your devices to enable trusted SSL access to services on your local subnet.
+        </p>
+        <a
+          href={~p"/download/ca"}
+          download
+          class="flex items-center justify-center gap-1 bg-blue-500 p-2 cursor-pointer rounded-md w-full"
+        >
+          <.icon name="hero-arrow-down-tray" class="h-5 w-5" />
+          <div class="truncate text-xs">Download Root CA</div>
+        </a>
+      </div>
     </div>
     """
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tunneld.MixProject do
   def project do
     [
       app: :tunneld,
-      version: "0.9.2",
+      version: "0.10.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
…paths updats to ca and certs, dnsmasq module to update config split-horizon dns, nginx server block for ssl and path to generated certs, create and delete certs with resources, create and delete dns entry for local resolution with resources, zrok helpers to get TLD and SLD for control plane